### PR TITLE
setup.py: Use GitHub url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author = 'Michel Casabianca',
     author_email = 'casa@sweetohm.net',
     packages = ['http1'],
-    url = 'http://pypi.python.org/pypi/http1/',
+    url = 'https://github.com/c4s4/http1',
     license = 'Apache Software License',
     description = 'http1 is an API to perform HTTP requests in a single call',
     long_description=open('README.rst', encoding='UTF-8').read(),


### PR DESCRIPTION
There is no benefit for PyPI package
to link to the same PyPI package.